### PR TITLE
allow a bunch of other .sublime-* extensions to have comments

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -37,8 +37,20 @@ class JSON(Linter):
     def run(self, cmd, code):
         """Attempt to parse code as JSON, return '' if it succeeds, the error message if it fails."""
 
-        # Ignore comments in .sublime-settings files.
-        if os.path.splitext(self.filename)[1] == '.sublime-settings':
+        extensions = [
+            '.sublime-build',
+            '.sublime-commands',
+            '.sublime-completions',
+            '.sublime-keymap',
+            '.sublime-menu',
+            '.sublime-mousemap',
+            '.sublime-project',
+            '.sublime-settings',
+            '.sublime-workspace',
+        ]
+
+        # Ignore comments in .sublime-* files.
+        if os.path.splitext(self.filename)[1] in extensions:
             code = self.line_comment_re.sub('', code)
             code = self.block_comment_re.sub(self.strip_comment, code)
 


### PR DESCRIPTION
Probably not exhaustive.
.sublime-snippet, .sublime-package are not JSON
