### PR TITLE
Respect the 'strict' setting. Resolves #7

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -50,7 +50,7 @@ class JSON(Linter):
         """Attempt to parse code as JSON, return '' if it succeeds, the error message if it fails."""
 
         # Use ST's loose parser for its setting files.
-        strict = os.path.splitext(self.filename)[1] not in self.extensions
+        strict = self.settings().get('strict', os.path.splitext(self.filename)[1] not in self.extensions)
 
         try:
             if strict:


### PR DESCRIPTION
Make the plugin to respect the "strict" setting in global SublimeLinter settings file. Resolves issue #7
